### PR TITLE
Add new docs page for the <select> component:

### DIFF
--- a/packages/css-doc-page/src/App.jsx
+++ b/packages/css-doc-page/src/App.jsx
@@ -15,15 +15,15 @@ import ColorGuidelines from './views/colorGuidelines';
 import TypographyGuidelines from './views/typhographyGuidelines'
 import AccessibilitySpecifications from './views/accessibilitySpecifications';
 import InputDocs from './views/inputDocs';
-
-
+import SelectDocs from './views/components/selectDocs';
+import './App.scss';
 import {
   BrowserRouter as Router,
   Route,
   Redirect,
   Switch
 } from 'react-router-dom';
-import './App.scss';
+
 
 const routes = [
   {
@@ -89,6 +89,10 @@ const routes = [
   {
     path: '/Inputs',
     component: InputDocs
+  },
+  {
+    path: '/Selects',
+    component: SelectDocs
   }
 
 

--- a/packages/css-doc-page/src/assets/markdown/selects/default.md
+++ b/packages/css-doc-page/src/assets/markdown/selects/default.md
@@ -1,0 +1,99 @@
+# Select
+
+## Overview
+
+Represents a menu of options where the user can select a single option. This component depends on importing the behaviors js file inside the css package like so:
+
+```javascript
+import "@e-toast/css/behaviors.js"
+```
+
+The javascript file will allow detection of current and dynamically added selects to add the extra styles and functionality. Without it, you would need to manually customize the selects.
+
+As a word of caution: the "eds-select" class hides any select inside of the component. The behaviors.js injects logic that dynamically injects a div that behaves like a select with the options of the first select that is a child of the element with the "eds-select" class. The class can be applied to any element but a div is suggested. Any other element may break the functionality
+
+## Usage
+```interactive
+<div class="eds-select">
+    <select>
+        <option hidden>Choose one</option>
+        <option>First</option>
+        <option>Second</option>
+        <option>Third</option>
+    </select>
+</div>
+```
+
+## Variants
+
+Disabled
+
+
+```interactive
+<div class="eds-select" disabled>
+    <select>
+        <option>First</option>
+        <option>Second</option>
+    </select>
+</div>
+```
+
+```interactive
+<div class="eds-select">
+    <select disabled>
+        <option>First</option>
+        <option>Second</option>
+    </select>
+</div>
+```
+
+## Local Tokens
+
+| token | default value | description |
+| ----- | ------------- | ----------- |
+| $border-color | theme_colors.$secondary-dark | Color used for the select border | 
+| $background | theme_colors.$background | Color used for the background of the select and the list of items |
+| $height | 30px | height of the select |
+| $width | 185px | width of the select |
+| $select-radius | 30px | Radius for the select corners |
+| $select-padding | 6px 10px | Padding used in the select |
+| $list-radius | 8px | Radius for the list's borders |
+| $list-margin-top | 6px | Space between list and select | 
+| $item-padding | 8px 10px | Padding for each individual item |
+| $item-hover-text-color | theme_colors.$background | text color of an item when the mouse is over it |
+| $item-hover-background | theme_colors.$primary | background color of an item when the mouse is over it |
+| $disabled-border-color | theme_colors.$disabled | Border color of the select when it is disabled |
+| $disabled-text-color | theme_colors.$disabled | Text color of the select when it is disabled |
+| $font-color | theme_colors.$secondary-dark | Text color for both the select and the items in the list |
+| $font-name | theme_fonts.$select-font | Font used in the select and item list |
+| $font-weight | theme_fonts.$select-weight | Font weight used in the select and item list |
+| $font-size | theme_fonts.$select-size | Font size used in the select and item list |
+| $line-height | theme_fonts.$select-line-height | Line height used in the select and item list |
+| $spacing | theme_fonts.$select-spacing | Letter spacing used in the select and item list |
+
+
+## Theme Tokens
+
+| token | default value | description |
+| ----- | ------------- | ----------- |
+| $background | globals.colors.$white | White color |
+| $primary | globals.colors.$orange | Orange color |
+| $disabled | globals.colors.$disable | Disable color |
+| $secondary-dark | globals.colors.$lightgray-dark | Dark shade of lightgray |
+| $select-font | globals.fonts.$font-name | Font used alll over etoast |
+| $select-weight | globals.fonts.$regular | Regular font weight |
+| $select-size | globals.fonts.$px-button | Font size used in select text |
+| $select-line-height | 18px | Line height of select |
+| $select-spacing | 0.16px | Letter spacing |
+
+## Global Tokens
+
+| token | default value | description |
+| ----- | ------------- | ----------- |
+| $white | #fff | White color |
+| $orange | #DE411B | Orange color |
+| $disable | #D9D9D9 | Disabled color |
+| $lightgray-dark | #1c272b | Dark shade of lightgray color |
+| $font-name | Roboto | Default font used all around etoast |
+| $regular | 400 | Regular or Default font weight |
+| $px-button | 16px | Font size for buttons |

--- a/packages/css-doc-page/src/containers/sidebar/Sidebar.jsx
+++ b/packages/css-doc-page/src/containers/sidebar/Sidebar.jsx
@@ -68,7 +68,8 @@ function Sidebar() {
                             { label: 'Checkbox', url: '/Checkbox' },
                             { label: 'Text Field', url: '' },
                             { label: 'Toggle', url: '' },
-                            { label: 'Inputs', url: '/Inputs' }
+                            { label: 'Inputs', url: '/Inputs' },
+                            { label: 'Selects', url: '/Selects' }
                         ]}
                     />
                 </div>

--- a/packages/css-doc-page/src/views/components/selectDocs/index.js
+++ b/packages/css-doc-page/src/views/components/selectDocs/index.js
@@ -1,0 +1,3 @@
+import SelectDocs from "./selectDocs";
+
+export default SelectDocs

--- a/packages/css-doc-page/src/views/components/selectDocs/selectDocs.jsx
+++ b/packages/css-doc-page/src/views/components/selectDocs/selectDocs.jsx
@@ -1,0 +1,36 @@
+import React from "react";
+import textDefault from "../../../assets/markdown/selects/default.md";
+import ButtonsIcon from "../../../assets/img/button-docs.svg";
+import Markdown from "../../../components/markdown";
+import Hero from "../../../components/hero";
+import styles from "./selectDocs.module.scss";
+
+const SelectDocs = () => {
+  // Select Docs Page
+  return (
+    <div className={styles.SelectDocs}>
+      <Hero
+        title="Selects"
+        text="Express what action will occur on a page when the user interacts with them"
+        image={ButtonsIcon}
+        secondary
+      />
+      <main className={styles.Main}>
+        <header className={styles.MainHeader}>
+          <h1 className={styles.MainTitle}>Select</h1>
+          <div class="eds-select">
+            <select>
+              <option hidden>Choose one</option>
+              <option>First</option>
+              <option>Second</option>
+              <option>Third</option>
+            </select>
+          </div>
+        </header>
+        <Markdown src={textDefault} />
+      </main>
+    </div>
+  );
+};
+
+export default SelectDocs;

--- a/packages/css-doc-page/src/views/components/selectDocs/selectDocs.module.scss
+++ b/packages/css-doc-page/src/views/components/selectDocs/selectDocs.module.scss
@@ -1,0 +1,37 @@
+.SelectDocs {
+  text-align: left;
+
+  .Main {
+    padding: 40px 110px;
+
+    &HeaderContent {
+      font-size: 16px;
+      line-height: 24px;
+    }
+
+    &Title {
+      font-size: 29px;
+      text-transform: uppercase;
+      color: var(--landing-primary);
+    }
+  }
+  .DocChooser {
+    display: flex;
+  }
+  .Select {
+    max-width: 185px;
+
+    &Label {
+      color: var(--landing-primary);
+      font-size: 16px;
+      line-height: 24px;
+      margin-bottom: 8px;
+    }
+  }
+  .IconToggle {
+    flex-grow: 1;
+    display: flex;
+    align-items: flex-end;
+    padding-left: 25px;
+  }
+}

--- a/packages/css-doc-page/src/views/index.js
+++ b/packages/css-doc-page/src/views/index.js
@@ -10,4 +10,4 @@ export { default as ShapeGuidelines } from './ShapeGuidelines'
 export { default as TokenPrinciples } from './TokenPrinciples'
 export { default as TyphographyGuidelines } from './TyphographyGuidelines'
 export { default as InputDocs } from './InputDocs'
-
+export { default as SelectDocs } from './SelectDocs'


### PR DESCRIPTION
- New <select> doc page
-- <select> base styles
- Copy markdown file for <select> on the assets folder
- Edit index view and add a new export for SelectDocs
- Edit Sidebar Menu add a new children for /Selects route
- Edit App.jsx importing the SelectDocs view