### PR TITLE
Fixing select styles

### DIFF
--- a/packages/css/src/atoms/selects/select.scss
+++ b/packages/css/src/atoms/selects/select.scss
@@ -7,9 +7,9 @@
     color: tokens.$font-color;
     letter-spacing: tokens.$spacing;
     line-height: tokens.$line-height;
-    overflow: hidden;
     cursor: pointer;
     user-select: none;
+    position: relative;
 
     & select {
         display: none;
@@ -32,23 +32,12 @@
         justify-content: flex-start;
         align-items: center;
 
-        &__disabled{
-            cursor: not-allowed;
-            border: {
-                color: tokens.$disabled-border-color;
-            }
-        }
-
         &__content {
             display: block;
             overflow: hidden;
             text-overflow: ellipsis;
             white-space: nowrap;
             width:129px;
-
-            &__disabled {
-                color: tokens.$disabled-border-color;
-            }
         }
 
         &__arrow {
@@ -64,18 +53,17 @@
                 &--open {
                     transform: rotate(180deg);
                 }
-                &__disabled{
-                    color: tokens.$disabled-border-color;
-                }
             }
         }
     }
    
     &__list {
+        z-index: 2;
         display: none;        
         width: min(100%, #{tokens.$width});
         overflow: hidden;
-        margin-top: #{tokens.$list-margin-top};
+        position: absolute;
+        top: calc(100% + #{tokens.$list-margin-top});
         border: {
             width: 1px;
             style: solid;
@@ -102,5 +90,26 @@
             color: tokens.$item-hover-text-color;
             background-color: tokens.$item-hover-background;
         }
+    }
+
+    & > select:disabled ~ &__selected,
+    &[disabled] > &__selected,
+    & > select.eds-select--disabled ~ &__selected,
+    &--disabled > &__selected {
+        cursor: not-allowed;
+        border: {
+            color: tokens.$disabled-border-color;
+        }
+    }
+
+    & > select:disabled ~ &__selected,
+    &[disabled] > &__selected,
+    & > select:disabled ~ &__selected > &__selected__arrow,
+    &[disabled] > &__selected > &__selected__arrow,
+    & > select.eds-select--disabled ~ &__selected,
+    &--disabled > &__selected,
+    & > select.eds-select--disabled ~ &__selected > &__selected__arrow,
+    &--disabled > &__selected > &__selected__arrow {
+        color: tokens.$disabled-text-color
     }
 }

--- a/packages/sandbox/src/App.js
+++ b/packages/sandbox/src/App.js
@@ -112,16 +112,14 @@ const InputDemo = ({ name, label, success, error='', ...extra }) => {
   </section>
 }
 
-const SelectDemo = ({ disabled, innerDisabled, placeholder="Choose one" }) => {
+const SelectDemo = ({ disabled, innerDisabled, disabledClass, placeholder="Choose one" }) => {
   const root = getClassName({
     base: "eds-select",
+    "&--disabled": disabledClass
   })
-
-  // const list = root.extend("&__list");
-  // const item = root.extend("&__option");
-
+  
   return <div className={root} disabled={disabled} >
-    <select defaultValue="1" disabled={innerDisabled} onChange={() => alert("aaaaa")}>
+    <select defaultValue="1" disabled={innerDisabled}>
       <option hidden>{placeholder}</option>
       <option value={1}>One</option>
       <option hidden>you dont see me</option>
@@ -368,6 +366,9 @@ function App() {
           </Padded>
           <Padded>
             <SelectDemo disabled placeholder="Disabled from container"/>
+          </Padded>
+          <Padded>
+            <SelectDemo disabledClass placeholder="Disabled using eds-list--disabled"/>
           </Padded>
         </div>
       </section>


### PR DESCRIPTION
The select styles had some issues I happened to find:
- Disabled wasn't disabling the select in sandbox
- The option list would push content when visible. No select should do this
- Disabled styles broke BEM rules

You might be inclined to remove the complex styles inside select.scss but they are made in a way that favors the etoast consumer experience. Remember selects are a special case of etoast in that they may use the javascript provided. With these changes, disabling a select is as simple as this:

```html
<select disabled class='eds-select'>
```

 or

```html
<select class='eds-select eds-select--disabled'>
```

or if javascript is not available:

```html
<div class="eds-select eds-select--disabled">
   <!-- Omitted no changes needed here -->
</div>
```

Compared to the current state of etoast selects (which currently disabling a select is impossible without manually writing the html that should have been generated by the javascript):

```html
<div class="eds-select">
        <span class="eds-select__selected eds-select__selected__disabled">
            <span class="eds-select__selected__content eds-select__selected__content__disabled">Selected</span>
            <span class="eds-select__selected__arrow">
                <span class="eds-select__selected__arrow__icon eds-select__selected__arrow__icon__disabled"></span>
            </span>
        </span>
        <div class="eds-select__list">
           <!-- Omitted -->
        </div>
</div>
```

The problem lies in having to place three disabled classes, that break the BEM standard, on somewhat arbitrary places. So , although the rules are a bit big and complex, they allow for a much better user experience.